### PR TITLE
Change "root" route to "blog_root" to avoid name clash with applications's "root" route

### DIFF
--- a/app/views/blogit/posts/_form.html.erb
+++ b/app/views/blogit/posts/_form.html.erb
@@ -37,7 +37,7 @@
 
   <%= actions do %>
     <%= f.submit %> <%=t :or, scope: 'blogit.posts'%>
-    <%= link_to(t(:cancel, scope: 'blogit.posts'), @post.new_record? ? root_path : post_path(@post)) %>
+    <%= link_to(t(:cancel, scope: 'blogit.posts'), @post.new_record? ? blog_root_path : post_path(@post)) %>
   <% end %>
 
 <% end %>

--- a/app/views/blogit/posts/index.rss.builder
+++ b/app/views/blogit/posts/index.rss.builder
@@ -1,21 +1,21 @@
 xml.instruct!
 xml.rss "version" => "2.0", "xmlns:dc" => "htt://purl.org/dc/elements/1.1/" do
   xml.channel do
-    
+
     xml.title blogit_conf.rss_feed_title
-    
+
     xml.description blogit_conf.rss_feed_description
-    
+
     xml.pubDate CGI.rfc1123_date @posts.first.try(:updated_at)
-    
-    xml.link root_url
-    
+
+    xml.link blog_root_url
+
     xml.lastBuildDate CGI.rfc1123_date @posts.first.try(:updated_at)
-    
+
     xml.language blogit_conf.rss_feed_language
-    
+
     @posts.each do |post|
-    
+
       xml.item do
         xml.title post.title
         xml.description format_content(truncate(post.body, length: 400)).html_safe
@@ -24,7 +24,7 @@ xml.rss "version" => "2.0", "xmlns:dc" => "htt://purl.org/dc/elements/1.1/" do
         xml.guid post_url(post)
         xml.author post.blogger_display_name
       end
-    
+
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,12 @@
 Blogit::Engine.routes.draw do
-  
+
   # Keep these above the posts resources block
   match "posts/page/:page" => "posts#index"
   match "posts/tagged/:tag" => 'posts#tagged', as: :tagged_blog_posts
-    
+
   resources :posts do
     resources :comments, only: [:create, :destroy]
   end
 
-  root to: "posts#index"
+  # root to: "posts#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,5 +8,5 @@ Blogit::Engine.routes.draw do
     resources :comments, only: [:create, :destroy]
   end
 
-  # root to: "posts#index"
+  match "/" => "posts#index", as: :blog_root
 end

--- a/spec/dummy/config/initializers/blogit.rb
+++ b/spec/dummy/config/initializers/blogit.rb
@@ -59,4 +59,10 @@ Blogit.configure do |config|
   # config.redcarpet_options = [:hard_wrap, :filter_html, :autolink,
   #   :no_intraemphasis, :fenced_code, :gh_blockcode]
 
+  # If set to true, it will be possible to call named routes of the main app
+  # directly, without the "main_app." prefix.
+  # Useful in the case where you don't want to change the main app's layout,
+  # but it does not expand correctly from inside blogit because some main
+  # app's named routes are missing.
+  config.inline_main_app_named_routes = true
 end


### PR DESCRIPTION
If you're using

```
config.inline_main_app_named_routes = true
```

which you probably want if you add blogit to your existing rails app, then a link in the nab to root got overridden by Blogit::Engine to "/blog" (or whatever you set it to be in your app's routes.rb). That's imho no way to go, because I want links to home page to still point to /.

This patch let's you keep on using root for your home page and adds blog_root to entry point for blogit.

Unfortunately I'm not able to run the tests (via rspec) because of database errors I'm not familiar with.
