### PR TITLE
Prevent the rss from containing incomplete textile or markdown for links or images

### DIFF
--- a/app/models/blogit/post.rb
+++ b/app/models/blogit/post.rb
@@ -4,6 +4,8 @@ module Blogit
     require "acts-as-taggable-on"
     require "kaminari"
 
+    include ::ActionView::Helpers::TextHelper
+
     acts_as_taggable
 
     self.table_name = "blog_posts"
@@ -14,6 +16,10 @@ module Blogit
     # = Attributes =
     # ==============
     attr_accessible :title, :body, :tag_list, :blogger_type, :blogger_id
+
+    def short_body
+      truncate(body, length: 400, separator: "\n")
+    end
 
     # ===============
     # = Validations =

--- a/app/views/blogit/posts/index.rss.builder
+++ b/app/views/blogit/posts/index.rss.builder
@@ -13,12 +13,12 @@ xml.rss "version" => "2.0", "xmlns:dc" => "htt://purl.org/dc/elements/1.1/" do
     xml.lastBuildDate CGI.rfc1123_date @posts.first.try(:updated_at)
 
     xml.language I18n.locale
-    
+
     @posts.each do |post|
 
       xml.item do
         xml.title post.title
-        xml.description format_content(truncate(post.body, length: 400)).html_safe
+        xml.description format_content(post.short_body).html_safe
         xml.link post_url(post)
         xml.pubDate CGI.rfc1123_date(post.updated_at)
         xml.guid post_url(post)

--- a/spec/controllers/blogit/posts_controller_spec.rb
+++ b/spec/controllers/blogit/posts_controller_spec.rb
@@ -110,17 +110,19 @@ describe PostsController do
           @current_blogger.expects(:blog_posts).returns(@blog_posts)
           @blog_posts.expects(:new).with(post_attributes.stringify_keys).returns(blog_post)
           blog_post.expects(:save).returns(true)
+          @pingr = mock()
+          @pingr.stub_everything()
         end
 
         it "should redirect to the blog post page" do
           do_post
           response.should redirect_to(controller.posts_url)
         end
-        
+
         it "should ping all search engines in ping_search_engines config if array" do
           Blogit.configuration.ping_search_engines = search_engines = [:google]
           search_engines.each do |search_engine|
-            Pingr::Request.expects(:new).with(search_engine, controller.posts_url(format: :xml))
+            Pingr::Request.expects(:new).with(search_engine, controller.posts_url(format: :xml)).returns(@pingr)
           end
           do_post
         end
@@ -128,7 +130,7 @@ describe PostsController do
         it "should ping all search engines in Pingr::SUPPORTED_SEARCH_ENGINES if config is true" do
           Blogit.configuration.ping_search_engines = true
           Pingr::SUPPORTED_SEARCH_ENGINES.each do |search_engine|
-            Pingr::Request.expects(:new).with(search_engine, controller.posts_url(format: :xml))
+            Pingr::Request.expects(:new).with(search_engine, controller.posts_url(format: :xml)).returns(@pingr)
           end
           do_post
         end
@@ -195,6 +197,8 @@ describe PostsController do
         mock_login
         @current_blogger.expects(:blog_posts).returns(@blog_posts = [])
         @blog_posts.expects(:find).with("1").returns(blog_post)
+        @pingr = mock()
+        @pingr.stub_everything()
       end
 
       def do_put
@@ -215,11 +219,11 @@ describe PostsController do
         do_put
         flash[:notice].should be_present
       end
-      
+
       it "should ping all search engines in ping_search_engines config if array" do
         Blogit.configuration.ping_search_engines = search_engines = [:google, :bing]
         search_engines.each do |search_engine|
-          Pingr::Request.expects(:new).with(search_engine, controller.posts_url(format: :xml))
+          Pingr::Request.expects(:new).with(search_engine, controller.posts_url(format: :xml)).returns(@pingr)
         end
         do_put
       end
@@ -227,7 +231,7 @@ describe PostsController do
       it "should ping all search engines in Pingr::SUPPORTED_SEARCH_ENGINES if config is true" do
         Blogit.configuration.ping_search_engines = true
         Pingr::SUPPORTED_SEARCH_ENGINES.each do |search_engine|
-          Pingr::Request.expects(:new).with(search_engine, controller.posts_url(format: :xml))
+          Pingr::Request.expects(:new).with(search_engine, controller.posts_url(format: :xml)).returns(@pingr)
         end
         do_put
       end
@@ -239,7 +243,7 @@ describe PostsController do
         end
         do_put
       end
-      
+
     end
 
     context "when not logged in" do
@@ -293,6 +297,8 @@ describe PostsController do
         mock_login
         @current_blogger.expects(:blog_posts).returns(@blog_posts = [])
         @blog_posts.expects(:find).with("1").returns(blog_post)
+        @pingr = mock()
+        @pingr.stub_everything()
       end
 
       it "should destroy the blog post" do
@@ -309,11 +315,11 @@ describe PostsController do
         do_delete
         flash[:notice].should be_present
       end
-      
+
       it "should ping all search engines in ping_search_engines config if array" do
         Blogit.configuration.ping_search_engines = search_engines = [:google, :bing]
         search_engines.each do |search_engine|
-          Pingr::Request.expects(:new).with(search_engine, controller.posts_url(format: :xml))
+          Pingr::Request.expects(:new).with(search_engine, controller.posts_url(format: :xml)).returns(@pingr)
         end
         do_delete
       end
@@ -321,7 +327,7 @@ describe PostsController do
       it "should ping all search engines in Pingr::SUPPORTED_SEARCH_ENGINES if config is true" do
         Blogit.configuration.ping_search_engines = true
         Pingr::SUPPORTED_SEARCH_ENGINES.each do |search_engine|
-          Pingr::Request.expects(:new).with(search_engine, controller.posts_url(format: :xml))
+          Pingr::Request.expects(:new).with(search_engine, controller.posts_url(format: :xml)).returns(@pingr)
         end
         do_delete
       end

--- a/spec/models/blogit/post_spec.rb
+++ b/spec/models/blogit/post_spec.rb
@@ -148,4 +148,25 @@ describe Blogit::Post do
 
   end
 
+  describe "body preview" do
+    it "should not truncate a short body" do
+      post = Blogit::Post.new(body: "short body")
+
+      post.short_body.should == post.body
+    end
+
+    it "should not truncate a long body" do
+      post = Blogit::Post.new(body: "t\n"*300)
+
+      post.short_body.should == "t\n"*198 + "t..."
+    end
+
+    it "should not cut the body in the middle of an image declaration" do
+      body = "some text\n"*35 + '"!http://www.images.com/blogit/P6876.thumb.jpg(Look at this)!\":http://www.images.com/blogit/P6976.jpb'
+      post = Blogit::Post.new(body: body)
+
+      post.short_body.should_not include('"!http://www.images.com')
+    end
+  end
+
 end


### PR DESCRIPTION
Hi Gavin,

I had this issue on the rss feed of [my blog](https://www.mes-courses.fr/blog/posts.rss), for example, with textile, I got things like that in the post :

```
“!https://dl.dropbox.com/u/206938/mes-courses.fr/images/articles/visite-a-l-aquarium-de-paris/…
```

What do you think about it ?
Thanks,
