### PR TITLE
Return table name for blog posts

### DIFF
--- a/app/models/blogit/post.rb
+++ b/app/models/blogit/post.rb
@@ -3,6 +3,8 @@ module Blogit
 
     require "kaminari"
 
+    self.table_name = "blog_posts"
+
     # ===============
     # = Validations =
     # ===============


### PR DESCRIPTION
In rails4 branch there is no "table_name" for Blogit::Post model which causes error, because migrations create "blog_posts" table and without "table_name" app expects "blogit_posts" talbe. This commit fixes it.
