### PR TITLE
Rails 4 cache sweepers

### DIFF
--- a/app/sweepers/blogit/blogit_sweeper.rb
+++ b/app/sweepers/blogit/blogit_sweeper.rb
@@ -1,4 +1,7 @@
+require 'rails/observers/active_model/observing'
+require 'rails/observers/activerecord/observer'
 require 'rails/observers/action_controller/caching'
+
 module Blogit
   
   # This is a universal cache sweeper. If a comment is added or a 

--- a/app/sweepers/blogit/blogit_sweeper.rb
+++ b/app/sweepers/blogit/blogit_sweeper.rb
@@ -1,3 +1,4 @@
+require 'rails/observers/action_controller/caching'
 module Blogit
   
   # This is a universal cache sweeper. If a comment is added or a 

--- a/blogit.gemspec
+++ b/blogit.gemspec
@@ -33,5 +33,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "mocha"
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "sqlite3"
+  s.add_development_dependency "rails-observers"
   s.add_development_dependency "rb-inotify",  ">= 0.8.8"
 end

--- a/lib/blogit.rb
+++ b/lib/blogit.rb
@@ -9,6 +9,8 @@ require "blogit/engine"
 require "blogit/parsers"
 
 require "validators"
+require 'rails/observers/action_controller/caching'
+
 module Blogit
   
   autoload :Kaminari, "kaminari"

--- a/lib/blogit.rb
+++ b/lib/blogit.rb
@@ -9,7 +9,6 @@ require "blogit/engine"
 require "blogit/parsers"
 
 require "validators"
-require 'rails/observers/action_controller/caching'
 
 module Blogit
   


### PR DESCRIPTION
Cache sweepers and observers moved to separate gem in rails4. I added this gem to gemspec and fixed load order so now sweepers do not throw errors.
