### PR TITLE
Add additional (optional) syntax highlight renderer: pygments.rb

### DIFF
--- a/blogit.gemspec
+++ b/blogit.gemspec
@@ -20,11 +20,12 @@ Gem::Specification.new do |s|
   s.add_dependency 'redcarpet', ">=2.0.1"
   s.add_dependency 'nokogiri', '>=1.5.0'
   s.add_dependency "albino", ">=1.3.3"
+  s.add_dependency "pygments.rb", ">=0.5.2"
   s.add_dependency 'acts-as-taggable-on', '>=2.2.1'
   s.add_dependency "kaminari", '>=0.13.0'
   s.add_dependency "jquery-rails"
   s.add_dependency "pingr", ">= 0.0.3"
-  
+
   s.add_development_dependency 'rb-fsevent', '~> 0.9.1'
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "guard"

--- a/lib/blogit/configuration.rb
+++ b/lib/blogit/configuration.rb
@@ -36,6 +36,10 @@ module Blogit
     #   is :markdown
     attr_accessor :highlight_code_syntax
 
+    # Which syntax highlighter to use
+    # Defaults to :albino
+    attr_accessor :syntax_highlighter
+
     # The name of the before filter we'll call to authenticate the current user.
     # Defaults to :login_required
     attr_accessor :authentication_method
@@ -87,11 +91,11 @@ module Blogit
     # when posts are created, updated or destroyed?
     # Defaults to false
     attr_accessor :ping_search_engines
-    
+
     # The layout to be used by the posts controller
     # Defaults to nil
     attr_accessor :layout
-    
+
     # When using redcarpet as content parser, pass these options as defaults.
     REDCARPET_OPTIONS = {
       hard_wrap: true,
@@ -119,6 +123,7 @@ module Blogit
       @cache_pages                 = false
       @default_parser              = :markdown
       @highlight_code_syntax       = true
+      @syntax_highlighter          = :albino
       @rss_feed_title              = "#{Rails.application.engine_name.titleize} Blog Posts"
       @rss_feed_description        = "#{Rails.application.engine_name.titleize} Blog Posts"
       @ping_search_engines         = false
@@ -150,7 +155,7 @@ module Blogit
     def rss_feed_language=(locale)
       blogit_warn "#{self.class}#rss_feed_language has been deprecated. You can remove this from your blogit.rb configuration file"
     end
-    
+
     private
 
     def blogit_warn(message)

--- a/lib/blogit/parsers/markdown_parser.rb
+++ b/lib/blogit/parsers/markdown_parser.rb
@@ -1,38 +1,37 @@
 class Blogit::Parsers::MarkdownParser
-  
+
   require "nokogiri"
-  require "albino"
   require "blogit/renderers"
-    
+
   def initialize(content)
     @content = content
   end
 
   def parsed
     ensure_pygments_is_installed if Blogit::configuration.highlight_code_syntax
-    
-    renderer = Blogit::configuration.highlight_code_syntax ?  Redcarpet::Render::HTMLWithAlbino : Redcarpet::Render::HTML
+
+    renderer = Blogit::configuration.highlight_code_syntax ? Blogit::Renderers::choose_highlight_renderer : Redcarpet::Render::HTML
     markdown = Redcarpet::Markdown.new(renderer, Blogit.configuration.redcarpet_options)
     html_content = markdown.render(@content).html_safe
   end
 
   private
-  
+
   def ensure_pygments_is_installed
     warning = <<-WARNING
 [blogit] The pygmentize command could not be found in your load path!
          Please either do one of the following:
 
          $ sudo easy_install Pygments # to install it
-         
-         or 
-         
+
+         or
+
          set config.highlight_code_syntax to false in your blogit.rb config file.
-         
+
 WARNING
     raise warning unless which(:pygmentize)
   end
-  
+
   # Check if an executable exists in the load path
   # Returns nil if no executable is found
   def which(cmd)
@@ -45,5 +44,5 @@ WARNING
     end
     return nil
   end
-  
+
 end

--- a/lib/blogit/renderers.rb
+++ b/lib/blogit/renderers.rb
@@ -1,3 +1,17 @@
 module Blogit::Renderers
-  require "blogit/renderers/html_with_albino"
+
+  def self.choose_highlight_renderer
+    case Blogit::configuration.syntax_highlighter
+    when :albino
+      require "blogit/renderers/html_with_albino"
+      Redcarpet::Render::HTMLWithAlbino
+    when :pygments
+      require "blogit/renderers/html_with_pygments"
+      Redcarpet::Render::HTMLWithPygments
+    else
+      raise Blogit::ConfigurationError,
+        "'#{Blogit.configuration.syntax_highlighter}' is not a valid renderer"
+    end
+  end
+
 end

--- a/lib/blogit/renderers/html_with_albino.rb
+++ b/lib/blogit/renderers/html_with_albino.rb
@@ -1,8 +1,9 @@
 # create a custom renderer that allows highlighting of code blocks
 class Redcarpet::Render::HTMLWithAlbino < Redcarpet::Render::HTML
-  
+
   def block_code(code, language)
+    require "albino"
     Albino.colorize(code, language)
   end
-  
+
 end

--- a/lib/blogit/renderers/html_with_pygments.rb
+++ b/lib/blogit/renderers/html_with_pygments.rb
@@ -1,0 +1,9 @@
+# create a custom renderer that allows highlighting of code blocks
+class Redcarpet::Render::HTMLWithPygments < Redcarpet::Render::HTML
+
+  def block_code(code, language)
+    require "pygments"
+    Pygments.highlight(code, lexer: language)
+  end
+
+end

--- a/lib/generators/templates/blogit.rb
+++ b/lib/generators/templates/blogit.rb
@@ -51,8 +51,12 @@ Blogit.configure do |config|
   # config.default_parser = :markdown
 
   # If blog content contains code, this should be highlighted using
-  # albino.
+  # either albino or pygments.rb.
   # config.highlight_code_syntax = true
+
+  # If code syntax should be highlighted use one of
+  # :albino or :pygments to highlight it.
+  # config.syntax_highlighter = :albino
 
   # RSS Feed title content
   # config.rss_feed_title = "A blog about ponies!"
@@ -62,13 +66,13 @@ Blogit.configure do |config|
 
   # Should blogit ping search engines with your sitemap
   # when posts are created, updated or destroyed?
-  # 
+  #
   # Can pass true to ping all supported search engines, or an array of search
   # engine names. e.g. [:google, :bing]
-  # 
+  #
   # Defaults to false
   # config.ping_search_engines = false
-  
+
   # When using redcarpet as content parser, pass these options as defaults.
   # @see here for more options: https://github.com/tanoku/redcarpet
   # config.redcarpet_options = {
@@ -87,6 +91,6 @@ Blogit.configure do |config|
   # app's named routes are missing.
   # config.inline_main_app_named_routes = true
 
-  # If this is set, Blogit::PostsController will use the layout named here 
+  # If this is set, Blogit::PostsController will use the layout named here
   # config.layout = "custom_layout"
 end


### PR DESCRIPTION
My editor cleans up whitespace automatically. That's why there are some related changes.
