### PR TITLE
Fix error when adding an active_record comment

### DIFF
--- a/app/views/blogit/comments/create.js.erb
+++ b/app/views/blogit/comments/create.js.erb
@@ -3,5 +3,5 @@ var $form = $("form#new_blog_comment");
   $("#comments").append("<%= escape_javascript(render(@comment)) %>");
   $form.get(0).reset();
 <% else %>
-  $form.html("<%= escape_javascript(render('form')) %>");
+  $form.html("<%= escape_javascript(render(partial:'form', locals: { post: @comment.post, comment: @comment })) %>");
 <% end %>


### PR DESCRIPTION
post in _form is not defined when called via render('form').
It throws an error.
