### PR TITLE
fix rails 4.0/4.1 deprecation message for delete links

### DIFF
--- a/app/views/blogit/comments/_admin_links.html.erb
+++ b/app/views/blogit/comments/_admin_links.html.erb
@@ -1,3 +1,3 @@
 <%= login_required(class: "actions") do %>
-  <%= link_to(t(:delete, scope: 'blogit.comments'), [@post, comment], method: :delete, confirm: t(:are_you_sure_you_want_to_remove_this_comment, scope: 'blogit.comments')) %>
+  <%= link_to(t(:delete, scope: 'blogit.comments'), [@post, comment], method: :delete, data: { confirm: t(:are_you_sure_you_want_to_remove_this_comment, scope: 'blogit.comments') }) %>
 <% end %>

--- a/app/views/blogit/posts/_post_links.html.erb
+++ b/app/views/blogit/posts/_post_links.html.erb
@@ -1,5 +1,6 @@
 <%= login_required do  %>
   <%= actions do %>
-    <%= link_to(t(:edit, scope: 'blogit.posts'), edit_post_path(post)) %> | <%= link_to(t(:delete, scope: 'blogit.posts'), post, method: :delete, confirm: t(:are_you_sure_you_want_to_remove_this_post, scope: 'blogit.posts')) %>
+    <%= link_to(t(:edit, scope: 'blogit.posts'), edit_post_path(post)) %> | <%= link_to(t(:delete, scope: 'blogit.posts'), post,
+      method: :delete, data: { confirm: t(:are_you_sure_you_want_to_remove_this_post, scope: 'blogit.posts')}) %>
   <% end %>
 <% end unless blogit_conf.author_edits_only and not this_blogger?(post) %>


### PR DESCRIPTION
This is in relation to:

Rails 4.0 deprecates the :confirm option for the link_to helper. You should instead rely on a data attribute (e.g. data: { confirm: 'Are you sure?' }). This deprecation also concerns the helpers based on this one (such as link_to_if or link_to_unless).
