### PR TITLE
acts-as-taggable-on migration fix

### DIFF
--- a/db/migrate/20140414161010_add_taggings_counter_cache_to_tags.rb
+++ b/db/migrate/20140414161010_add_taggings_counter_cache_to_tags.rb
@@ -1,0 +1,13 @@
+class AddTaggingsCounterCacheToTags < ActiveRecord::Migration
+  def self.up
+    add_column :tags, :taggings_count, :integer, :default => 0
+
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, :taggings)
+    end
+  end
+
+  def self.down
+    remove_column :tags, :taggings_count
+  end
+end

--- a/db/migrate/20140414162019_add_missing_unique_indices.rb
+++ b/db/migrate/20140414162019_add_missing_unique_indices.rb
@@ -1,0 +1,21 @@
+class AddMissingUniqueIndices < ActiveRecord::Migration
+
+  def self.up
+    add_index :tags, :name, unique: true
+
+    remove_index :taggings, :tag_id
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+    add_index :taggings,
+      [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
+      unique: true, name: 'taggings_idx'
+   end
+
+  def self.down
+    remove_index :tags, :name
+
+    remove_index :taggings, name: 'taggings_idx'
+    add_index :taggings, :tag_id
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+end


### PR DESCRIPTION
The new migrations for the newer versions of the acts-as-taggable-on gem.
From: https://github.com/mbleigh/acts-as-taggable-on/tree/master/db/migrate
