### PR TITLE
Removed duplicate sqlite3 dev dependencies

### DIFF
--- a/blogit.gemspec
+++ b/blogit.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "kaminari", '>=0.13.0'
   s.add_dependency "jquery-rails"
   s.add_dependency "pingr", ">= 0.0.3"
-  
+
   s.add_development_dependency 'rails', '>= 4.0.0'
   s.add_development_dependency 'rb-fsevent'
   s.add_development_dependency "sqlite3"
@@ -33,6 +33,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "factory_girl", ">=4.1.0"
   s.add_development_dependency "mocha"
   s.add_development_dependency "rspec-rails"
-  s.add_development_dependency "sqlite3"
   s.add_development_dependency 'tzinfo'
 end


### PR DESCRIPTION
Just fixing the duplicate dev dependencies here. With them, you get the following error:

```
blogit at /Users/johncblandii/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/bundler/gems/blogit-93138dd94434 did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  duplicate dependency on sqlite3 (>= 0, development), (>= 0) use:
    add_runtime_dependency 'sqlite3', '>= 0', '>= 0'
```
