### PR TITLE
Add ability to configure parent controller other than ApplicationController

### DIFF
--- a/app/controllers/blogit/application_controller.rb
+++ b/app/controllers/blogit/application_controller.rb
@@ -1,7 +1,7 @@
 module Blogit
 
   # Inherits from the application's controller instead of ActionController::Base
-  class ApplicationController < ::ApplicationController
+  class ApplicationController < "::#{Blogit.configuration.parent_controller}".constantize
 
     helper Blogit::ApplicationHelper, Blogit::PostsHelper
     helper_method :current_blogger, :blogit_conf
@@ -33,7 +33,7 @@ module Blogit
 
     # Returns true or false if current_blogger is present
     def is_blogger_logged_in?
-      !!current_blogger 
+      !!current_blogger
     end
 
     # Returns true if the current_blogger is the owner of the post

--- a/lib/blogit/configuration.rb
+++ b/lib/blogit/configuration.rb
@@ -98,6 +98,10 @@ module Blogit
     # list of states that will hide the posts from the public.
     attr_accessor :hidden_states
 
+    # Name of controller that Blogit::ApplicationController descends from
+    # Defaults to ApplicationController
+    attr_accessor :parent_controller
+
     # list of states for the Post state machine in order or lifecycle, aggregation of hidden_states and active_states
     #attr_accessor :post_states
 
@@ -140,6 +144,7 @@ module Blogit
       @redcarpet_options           = REDCARPET_OPTIONS
       @active_states               = ACTIVE_STATES
       @hidden_states               = HIDDEN_STATES
+      @parent_controller           = "ApplicationController"
     end
 
     def default_parser_class
@@ -167,7 +172,7 @@ module Blogit
     def rss_feed_language=(locale)
       blogit_warn "#{self.class}#rss_feed_language has been deprecated. You can remove this from your blogit.rb configuration file"
     end
-    
+
     def cache_pages=(value)
       blogit_warn "config.cache_pages is deprecated. Please remove this from your blogit.rb file"
     end

--- a/lib/generators/templates/blogit.rb
+++ b/lib/generators/templates/blogit.rb
@@ -93,4 +93,6 @@ Blogit.configure do |config|
   # List of states that will hide the posts from the public.
   # config.hidden_states = [:draft, :archive]
 
+  # Name of controller that Blogit::ApplicationController descends from
+  # config.parent_controller = "ApplicationController"
 end


### PR DESCRIPTION
Wanted `Blogit::ApplicationController` to extend from a controller other than `ApplicationController` in my app. This pull request gives you that ability :)
