### PR TITLE
Use Pygmentize instead of Albino for compatibility on Heroku

### DIFF
--- a/blogit.gemspec
+++ b/blogit.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'redcarpet', ">=2.0.1"
   s.add_dependency 'nokogiri', '>= 1.5.0'
   s.add_dependency "albino", ">=1.3.3"
+  s.add_dependency "pygmentize"
   s.add_dependency "kaminari", '>=0.13.0'
   s.add_dependency "jquery-rails"
   s.add_dependency "acts-as-taggable-on", "~> 3.5.0"

--- a/lib/blogit/renderers/html_with_albino.rb
+++ b/lib/blogit/renderers/html_with_albino.rb
@@ -1,8 +1,10 @@
 # Create a custom renderer that allows highlighting of code blocks
 class Redcarpet::Render::HTMLWithAlbino < Redcarpet::Render::HTML
-  
+
   def block_code(code, language)
-    Albino.colorize(code, language)
+    # Albino.colorize(code, language)
+    require "pygmentize"
+    Pygmentize.process(code, language.to_sym)
   end
-  
+
 end


### PR DESCRIPTION
I did this because Albino won't work for me on Heroku (I get an error about the Python package not being present). However, and as per #50, the `pygmentize` gem seems to be a drop-in replacement. So far, I've only tested it with one lexer (the one in [my first blog post](http://nkt-railsblog.herokuapp.com/blog/posts/1-the-call-of-ubuntu-2015)), but it seems to work nicely.
