### PR TITLE
Add pygments.rb (others posible) as optional code formatter :hourglass:

### DIFF
--- a/blogit.gemspec
+++ b/blogit.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "RedCloth", ">=4.2.9"
   s.add_dependency 'redcarpet', ">=2.0.1"
   s.add_dependency 'nokogiri', '>= 1.5.0'
+  # TODO (breaking change): should be removed and added manually to project using it
   s.add_dependency "albino", ">=1.3.3"
   s.add_dependency "kaminari"
   s.add_dependency "jquery-rails"

--- a/lib/blogit/configuration.rb
+++ b/lib/blogit/configuration.rb
@@ -1,22 +1,22 @@
 module Blogit
-  
+
   # This class handles the global configuration options for Blogit.
   #  When you run `rails g blogit:install` this will add an initializer file to
   #  config/initializers/blogit.rb with all of the default configurations applied.
   #
   #  You can read about each of the individual configuration options below.
   class Configuration
-    
+
     include ActiveSupport::Configurable
-    
-    # An Array containing the default states for {Blogit::Post Posts} that are considered 
+
+    # An Array containing the default states for {Blogit::Post Posts} that are considered
     #   "active". ("Active" {Post posts} are those that can be viewed by the public).
     ACTIVE_STATES = [:published]
 
-    # An Array containing the default states for {Blogit::Post Posts} that are considered 
+    # An Array containing the default states for {Blogit::Post Posts} that are considered
     #   "hidden". ("Hidden" {Post posts} are those that may not be viewed by the public).
-    HIDDEN_STATES = [:draft, :archive]    
-    
+    HIDDEN_STATES = [:draft, :archive]
+
     # When using redcarpet as content parser, pass these options as defaults.
     REDCARPET_OPTIONS = {
       hard_wrap: true,
@@ -26,94 +26,99 @@ module Blogit
       fenced_code_blocks: true,
       gh_blockcode: true,
     }
-    
-    ## 
+
+    ##
     # How do you want to handle comments for your blog?
-    #   Valid options are :active_record, :disquss, or :no for none. 
+    #   Valid options are :active_record, :disquss, or :no for none.
     #   (default: :active_record)
     config_accessor(:include_comments) { :active_record }
-    
-    ## 
+
+    ##
     # When using :disqus comments, what is the shortname of your forum?
     #  (default: nil)
     config_accessor(:disqus_shortname, instance_writer: false)
-    
+
     ##
     # Load a javascript-based share bar on each blog post?. (default: true)
     config_accessor(:include_share_bar) { true }
-    
+
     ##
     # Twitter username used in the share bar. (default: nil)
     config_accessor(:twitter_username)
-    
+
     ##
     # The name of the controller method we'll call to return the current blogger.
     #   (default: :current_user)
     config_accessor(:current_blogger_method) { :current_user }
-    
+
     ##
     # What method do we call on blogger to return their display name? (default: :username)
     config_accessor(:blogger_display_name_method) { :username }
-    
+
     ##
     # Which DateTime::FORMATS format do we use to display blog and comment publish time
     #   (default: :short)
     config_accessor(:datetime_format) { :short }
-    
+
     ##
     # Number of {Blogit::Post posts} to show per page. This is a configuration for {https://github.com/amatsuda/kaminari Kaminari} (default: 5)
     #
     # Returns an Integer
     config_accessor(:posts_per_page) { 5 }
-    
+
     ##
     # If set to true, the comments form will POST and DELETE to the comments
     # controller using AJAX calls.
     #
     # Returns true or false
     config_accessor(:ajax_comments)  { true }
-    
+
     ##
     # The default format for parsing the blog content.
     #
     # Defaults to :markdown
     config_accessor(:default_parser) { :markdown }
-    
+
     ##
     # Should text within "```" or "`" be highlighted as code?
     # Defaults to true
     # @note - At the moment this only works when default_parser is :markdown
     config_accessor(:highlight_code_syntax) { true }
-    
+
+    ##
+    # The renderer used for code highlighting
+    # Defaults to :albino
+    config_accessor(:syntax_highlighter) { :albino }
+
     ##
     # When using redcarpet as content parser, pass these options as defaults
     #
     # Defaults to {REDCARPET_OPTIONS}
     config_accessor(:redcarpet_options) { REDCARPET_OPTIONS }
-    
+
     ##
     # List of states that will be visible to the public
     #
     # Defaults to ACTIVE_STATES
     config_accessor(:active_states) { ACTIVE_STATES }
-    
+
     ##
     # List of states that will hide the posts from the public.
     #
     # Defaults to HIDDEN_STATES
     config_accessor(:hidden_states) { HIDDEN_STATES }
-    
+
     ##
     # The title of the RSS feed for the blog posts
     #
     # Defaults to "[Application Name] Blog Posts"
     config_accessor(:rss_feed_title, instance_reader: false)
-    
+
     ##
     # The description of the RSS feed for the blog posts
     # Defaults to "[Application Name] Blog Posts"
     config_accessor(:rss_feed_description, instance_reader: false)
-    
+
     ##
     # The layout to be used by the posts controller
     #
@@ -126,13 +131,13 @@ module Blogit
     #
     # Defaults to true
     config_accessor(:show_post_description) { true }
-    
-    
+
+
     def default_parser_class
       "Blogit::Parsers::#{default_parser.to_s.classify}Parser".constantize
     end
 
-    # Sets {#disqus_shortname}. 
+    # Sets {#disqus_shortname}.
     #   If the user has defined a disqus shortname but hasn't set include_comments to
     #   :disqus will print a warning to the console.
     #
@@ -155,19 +160,19 @@ module Blogit
       @rss_feed_title ||= "#{rails_app_name} Blog Posts"
     end
 
-    # The description to use in the index.rss template. 
+    # The description to use in the index.rss template.
     #   (default: "Latest from [My Application]")
     #
-    # Returns a String    
+    # Returns a String
     def rss_feed_description
       @rss_feed_description ||= "Latest from #{rails_app_name}"
     end
 
-    
-    
+
+
     private
 
-  
+
     # The name of this application derived from the app's engine name.
     #   If your Rails app module is KatanaCode, the application name will be "Katana Code"
     #
@@ -179,7 +184,7 @@ module Blogit
     # Print a warning message to $STDOUT with the prefix "[Blogit]: "
     #
     # Examples
-    # 
+    #
     #  blogit_warn("Blogit is not a toy!")
     #  # => "[Blogit]: Blogit is not a toy!"
     #
@@ -188,5 +193,5 @@ module Blogit
     end
 
   end
-  
+
 end

--- a/lib/blogit/parsers/markdown_parser.rb
+++ b/lib/blogit/parsers/markdown_parser.rb
@@ -1,17 +1,16 @@
 class Blogit::Parsers::MarkdownParser
-  
+
   require "nokogiri"
-  require "albino"
   require "blogit/renderers"
-  
-  # A String containing the content to be parsed  
+
+  # A String containing the content to be parsed
   attr_reader :content
-  
+
   def initialize(content)
     @content = content
   end
 
-  # The parsed content 
+  # The parsed content
   #
   # Returns an HTML safe String
   def parsed
@@ -21,26 +20,26 @@ class Blogit::Parsers::MarkdownParser
 
 
   private
-  
-  
+
+
   # The Redcarpet renderer to use
   def renderer
     if Blogit::configuration.highlight_code_syntax
-      Redcarpet::Render::HTMLWithAlbino
+      Blogit::Renderers.choose_highlight_renderer
     else
       Redcarpet::Render::HTML
     end
   end
-  
+
   # The Redcarpet Markdown handler
   def markdown
     @markdown ||= Redcarpet::Markdown.new(renderer,
       Blogit.configuration.redcarpet_options)
   end
 
-  
+
   # Ensures pygments is installed
-  # 
+  #
   # Raises StandardError if pygments is not available on this machine
   def ensure_pygments_is_installed
     warning = <<-WARNING
@@ -48,15 +47,15 @@ class Blogit::Parsers::MarkdownParser
          Please either do one of the following:
 
          $ sudo easy_install Pygments # to install it
-         
-         or 
-         
+
+         or
+
          set config.highlight_code_syntax to false in your blogit.rb config file.
-         
+
 WARNING
     raise warning unless which(:pygmentize)
   end
-  
+
   # Check if an executable exists in the load path
   #
   # Returns nil if no executable is found
@@ -70,5 +69,5 @@ WARNING
     end
     return nil
   end
-  
+
 end

--- a/lib/blogit/renderers.rb
+++ b/lib/blogit/renderers.rb
@@ -1,3 +1,15 @@
 module Blogit::Renderers
-  require "blogit/renderers/html_with_albino"
+  def self.choose_highlight_renderer
+    case Blogit::configuration.syntax_highlighter
+    when :albino
+      require "blogit/renderers/html_with_albino"
+      Redcarpet::Render::HTMLWithAlbino
+    when :pygments
+      require "blogit/renderers/html_with_pygments"
+      Redcarpet::Render::HTMLWithPygments
+    else
+      raise Blogit::ConfigurationError,
+        "'#{Blogit.configuration.syntax_highlighter}' is not a valid renderer"
+    end
+  end
 end

--- a/lib/blogit/renderers/html_with_albino.rb
+++ b/lib/blogit/renderers/html_with_albino.rb
@@ -1,8 +1,9 @@
 # Create a custom renderer that allows highlighting of code blocks
 class Redcarpet::Render::HTMLWithAlbino < Redcarpet::Render::HTML
-  
+  require "albino"
+
   def block_code(code, language)
     Albino.colorize(code, language)
   end
-  
+
 end

--- a/lib/blogit/renderers/html_with_pygments.rb
+++ b/lib/blogit/renderers/html_with_pygments.rb
@@ -1,0 +1,8 @@
+# Create a custom renderer that allows highlighting of code blocks
+class Redcarpet::Render::HTMLWithPygments < Redcarpet::Render::HTML
+  require "pygments"
+
+  def block_code(code, language)
+    Pygments.highlight(code, lexer: language)
+  end
+end

--- a/lib/generators/templates/blogit.rb
+++ b/lib/generators/templates/blogit.rb
@@ -30,8 +30,11 @@ Blogit.configure do |config|
   config.default_parser = :markdown
 
   # If blog content contains code, this should be highlighted using
-  # albino.
+  # one of the renderers.
   config.highlight_code_syntax = true
+
+  # The syntax highlighter to use when highlight_code_syntax is set.
+  config.syntax_highlighter = :albino
 
   # RSS Feed title content
   config.rss_feed_title = "#{Rails.application.engine_name.titleize} Blog Posts"


### PR DESCRIPTION
This commit adds the possibility to change the desired code formatter.
The default is still albino, but I added pygments.rb. Others can be added easily. It's configurable in the config file.

pygments however is not set up as a dependency. I think it's better not to add dependencies to all possible renderers when you always only need one. So my preferred way is to add the needed gem in the app's Gemfile. It will be required inside the renderer when it's needed.
In order to be backwards compatible I left the existing dependency to albino. However I would remove it from the gemspec file and bump the major version since one needs to add albino to the Gemfile as well then.

Master build seems broken so I can't tell anything about the tests.
