### PR TITLE
Translation and bug fixes for comments section

### DIFF
--- a/app/helpers/blogit/posts_helper.rb
+++ b/app/helpers/blogit/posts_helper.rb
@@ -1,13 +1,13 @@
 module Blogit
   module PostsHelper
-    
+
     require "blogit/archive"
-    
+
     # Renders the comments for a {Post} based on the
     # {Blogit::Configuration::include_comments} configuration
     def comments_for_post(post)
       comment_type = Blogit.configuration.include_comments
-      render(partial: "blogit/comments/#{comment_type}_comments", 
+      render(partial: "blogit/comments/#{comment_type}_comments",
         locals: { post: post, comment: Blogit::Comment.new })
     end
 
@@ -17,7 +17,7 @@ module Blogit
       return "" unless Blogit.configuration.include_share_bar
       render(partial: "blogit/posts/share_bar", locals: { post: post})
     end
-    
+
     # Returns the {Post Posts} that share one or more of the same tags for a given post
     #
     # post - A {Post} instance
@@ -25,6 +25,10 @@ module Blogit
     # Returns a collection of {Post Posts}
     def related_posts_for_post(post)
       post.find_related_on_tags.active
+    end
+
+    def show_comments_count?
+      Blogit.configuration.include_comments == :active_record
     end
 
     # Creates a ul tag tree with posts by year and months. Include blogit/archive.js in
@@ -38,7 +42,7 @@ module Blogit
     #            ...
     #          </ul>
     #        </div>
-    # 
+    #
     # Returns an HTML safe String
     def archive_list_for_posts(archive_posts)
       render Blogit::Archive::List.new(archive_posts)

--- a/app/views/blogit/comments/_active_record_comments.html.erb
+++ b/app/views/blogit/comments/_active_record_comments.html.erb
@@ -1,5 +1,5 @@
 <div class="blogit_comments_list">
-  <h3 class="blogit_comments_list__header blogit_header--section">Comments</h3>
+  <h3 class="blogit_comments_list__header blogit_header--section"><%= t(:comments, scope: 'blogit.posts') %></h3>
   <%= render post.comments %>
 </div>
 <%= render partial: "blogit/comments/form", locals: { post: post, comment: comment } %>

--- a/app/views/blogit/posts/_post.html.erb
+++ b/app/views/blogit/posts/_post.html.erb
@@ -1,16 +1,15 @@
-<%= content_tag(:article, id: "blogit_post_#{post.id}", 
+<%= content_tag(:article, id: "blogit_post_#{post.id}",
   class: "blogit_post blog_post--is_preview") do %>
 
   <%# Render the header for this blog post %>
   <%= render "blogit/posts/post_head", post: post %>
-  
+
   <%= render "blogit/posts/blogger_information", post: post %>
-  
+
   <%# Render the body of this blog post (as Markdown) %>
   <%= format_content(post.short_body) %>
 
   <%# Render the no. of comments %>
-  <%= render "blogit/posts/comments_count",
-    post: post if defined?(show_comments_count) and show_comments_count %>
+  <%= render "blogit/comments/comments_count", post: post if show_comments_count? %>
 
 <% end %>

--- a/app/views/blogit/posts/index.html.erb
+++ b/app/views/blogit/posts/index.html.erb
@@ -8,10 +8,8 @@
   <% if @posts.any? %>
     <%= render partial: "blogit/posts/post",
       collection: @posts,
-      spacer_template: "blog_post_spacer",
-      locals: { 
-        show_comments_count: (Blogit.configuration.include_comments == :active_records) 
-      }  %>
+      spacer_template: "blog_post_spacer"
+    %>
   <% else %>
 
     <%= render partial: "blogit/posts/empty" %>

--- a/app/views/blogit/posts/show.html.erb
+++ b/app/views/blogit/posts/show.html.erb
@@ -3,7 +3,7 @@
 
 <%= content_tag(:article, id: "blogit_post_#{@post.id}", class: "blogit_post") do %>
 
-  
+
   <%# Render the header for this blog post %>
   <%= render "blogit/posts/post_head", post: @post %>
 
@@ -16,8 +16,7 @@
   <%= share_bar_for_post @post %>
 
   <%# Render the no. of comments %>
-  <%= render "blogit/posts/comments_count",
-    post: post if defined?(show_comments_count) and show_comments_count %>
+  <%= render "blogit/comments/comments_count", post: @post if show_comments_count? %>
 
   <%= render "blogit/posts/tags", post: @post %>
   <%= render "blogit/posts/related", post: @post %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -32,7 +32,7 @@ de:
       delete: "löschen"
       are_you_sure_you_want_to_remove_this_post: "Bist Du sicher, dass Du den Beitrag löschen möchtest?"
       comments: "Kommentare"
-      comment:
+      comments_count:
         one: "ein Kommentar"
         other: "%{count} Kommentare"
       edit_blog_post: "Beitrag #%{id} bearbeiten"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -31,6 +31,7 @@ de:
       edit: "bearbeiten"
       delete: "löschen"
       are_you_sure_you_want_to_remove_this_post: "Bist Du sicher, dass Du den Beitrag löschen möchtest?"
+      comments: "Kommentare"
       comment:
         one: "ein Kommentar"
         other: "%{count} Kommentare"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,7 +29,7 @@ en:
       delete: "delete"
       are_you_sure_you_want_to_remove_this_post: "Are you sure you want to remove this post?"
       comments: "Comments"
-      comment:
+      comments_count:
         one: "1 comment"
         other: "%{count} comments"
       edit_blog_post: "Edit Blog Post #%{id}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,7 @@ en:
       edit: "edit"
       delete: "delete"
       are_you_sure_you_want_to_remove_this_post: "Are you sure you want to remove this post?"
+      comments: "Comments"
       comment:
         one: "1 comment"
         other: "%{count} comments"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -27,6 +27,7 @@ fr:
       edit: "editer"
       delete: "supprimer"
       are_you_sure_you_want_to_remove_this_post: "Etes vous certain de vouloir supprimer cet article?"
+      comments: "Commentaires"
       comment:
         zero: "Aucun commentaire"
         one: "1 commentaire"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -28,7 +28,7 @@ fr:
       delete: "supprimer"
       are_you_sure_you_want_to_remove_this_post: "Etes vous certain de vouloir supprimer cet article?"
       comments: "Commentaires"
-      comment:
+      comments_count:
         zero: "Aucun commentaire"
         one: "1 commentaire"
         other: "%{count} commentaires"


### PR DESCRIPTION
This PR adds one more translation key to i18nify the comments section title and adds l10n for the 3 given languages.
Additionally it fixes the rendering of the comments counter for active_record comments which didn't show up because of several reasons.
