### PR TITLE
Fix bug where comments controller couldn't find helper methods…

### DIFF
--- a/app/controllers/blogit/comments_controller.rb
+++ b/app/controllers/blogit/comments_controller.rb
@@ -1,18 +1,18 @@
 module Blogit
-  
-  # Handles requests for creating Blogit::Comments 
-  class CommentsController < ApplicationController
+
+  # Handles requests for creating Blogit::Comments
+  class CommentsController < ::Blogit::ApplicationController
 
     # Accessor method for the comment being created
     #
     # Returns a Blogit::Comment
     attr_reader :comment
-    
+
     # Accessor method for the Post we're adding a Comment to
     #
     # Returns Post
     attr_reader :post
-    
+
     # Handles POST requests to /blogit/comments.html and /blogit/comments.js
     #
     # Yields #comment if called with a block (useful for calling super from subclasses)
@@ -46,23 +46,23 @@ module Blogit
       render status: (comment.persisted? ? :created : :bad_request)
     end
 
-    # The create action render call when format is HTML    
+    # The create action render call when format is HTML
     def create_respond_to_html
       if comment.persisted?
-        redirect_to(post, 
+        redirect_to(post,
           notice: t(:successfully_added_comment, scope: 'blogit.comments'))
       else
         render "blogit/posts/show"
-      end  
+      end
     end
-    
-    # The comment attribute params 
-    # 
+
+    # The comment attribute params
+    #
     # Returns a Hash
     def comment_params
       params.require(:comment).permit(:name, :nickname, :email, :body, :website)
     end
-    
+
   end
-  
+
 end


### PR DESCRIPTION
…inside remote method call in main app.

This happens when you have your own ApplicationController in main app and try to create a new ActiveRecord comment. Without namespacing you'll get

```
undefined method `format_content' for #<#<Class:xxxxx>:yyyyyy>
```
